### PR TITLE
Separate the tests

### DIFF
--- a/cypress/integration/customer.spec.js
+++ b/cypress/integration/customer.spec.js
@@ -22,6 +22,9 @@ const documents = require('../../lib/gateways/document/s3')({
 require('cypress-file-upload');
 
 context('Customer Actions', () => {
+  after(() => {
+    cy.task('deleteDropboxes');
+  });
   const dropboxUrlRegex = /\/dropboxes\/([0-9a-zA-Z-_]{20})/;
 
   const getDropboxFromUrl = async url => {

--- a/cypress/integration/staff.spec.js
+++ b/cypress/integration/staff.spec.js
@@ -1,6 +1,25 @@
 /// <reference types="cypress" />
 
 context('Staff actions', () => {
+  before(() => {
+    const dropbox = {
+      customerPhone: '123',
+      submitted: '2020-08-24T13:57:53.285Z',
+      customerNationalInsurance: 'AAB111111C',
+      created: '2020-08-24T13:57:53.285Z',
+      customerEmail: 'me@test.com',
+      customerReference: '222',
+      description: 'description',
+      customerDob: '1999-12-31',
+      customerName: 'Jim'
+    };
+    cy.task('createDropbox', { ...dropbox, dropboxId: '1' });
+    cy.task('createDropbox', { ...dropbox, dropboxId: '2' });
+    cy.task('createDropbox', { ...dropbox, dropboxId: '3' });
+  });
+  after(() => {
+    cy.task('deleteDropboxes');
+  });
   context('when not logged in', () => {
     beforeEach(() => {
       cy.logout();

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
**What**  
Remove the dropboxes from the database after running the tests.
Manually add dropboxes into the database before running staff tests

**Why**  
To decouple tests.

**Anything else?**  
Add createDropbox and deleteDropboxes tasks to cypress/plugins
