### PR TITLE
Set content type when uploading

### DIFF
--- a/static/js/setContentType.js
+++ b/static/js/setContentType.js
@@ -1,0 +1,7 @@
+const uploadInput = document.querySelector('#file');
+const contentTypeInput = document.querySelector('#content-type');
+uploadInput.addEventListener('change', function(evt) {
+  evt.preventDefault();
+  const file = evt.target.files[0];
+  contentTypeInput.value = file.type;
+});

--- a/templates/createDropbox.hbs
+++ b/templates/createDropbox.hbs
@@ -50,6 +50,7 @@
           <option>Other</option>
         </select>
       </div>
+      <input type="hidden" name="Content-Type" id="content-type" />
       <label for="file">Select file</label>
       <input type="file" class="form-control" id="file" name="file" required />
     </div>
@@ -57,6 +58,7 @@
       <button type="submit" id="uploadFile" class="btn btn-block btn-lg btn-primary">Upload Document</button>
     </div>
   </form>
+  <script type="text/javascript" src="/assets/js/setContentType.js"></script>
 </section>
 {{#if dropbox.hasUploads }}
   <section>


### PR DESCRIPTION
**What**  
I want to set a content type for files uploaded to S3

**Why**  
So that the browser can handle a file if it's a known type (rather than just downloading)

