### PR TITLE
Add responsivness to the dropbox list

### DIFF
--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/assets/css/styles.css" />
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/responsive/2.2.5/js/dataTables.responsive.min.js"></script>
   <script src="/assets/js/bootstrap.min.js"></script>
   <script src="https://cdn.datatables.net/1.10.21/js/dataTables.bootstrap.min.js"></script>
 </head>

--- a/templates/staffDropboxList.hbs
+++ b/templates/staffDropboxList.hbs
@@ -71,7 +71,8 @@
 <script>
   $(function () {
     $('#unarchived-table').DataTable({
-      "order": []
+      "order": [],
+      responsive: true
     });
     $('#archived-table').DataTable({
       "order": []


### PR DESCRIPTION
**What**  
Make dropbox table responsive (only displays the amount of columns that fit on the screen)
<img width="340" alt="image" src="https://user-images.githubusercontent.com/54268893/91459402-869a3d80-e87e-11ea-8c13-fdc8a81e82a6.png">

**Why**  
For accessibility

**Anything else?**  
Add responsive script from DataTables
